### PR TITLE
Magento2 v2.2.0

### DIFF
--- a/app/code/Midtrans/Snap/Block/Close.php
+++ b/app/code/Midtrans/Snap/Block/Close.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Midtrans\Snap\Block;
+use \Magento\Framework\View\Element\Template;
+
+
+class Close extends Template
+{
+    public function __construct(\Magento\Framework\View\Element\Template\Context $context)
+    {
+        parent::__construct($context);
+    }
+
+    public function cancelOrders()
+    {
+        return __('Your order has been canceled, because you close payment page. Thank you');
+    }
+
+}

--- a/app/code/Midtrans/Snap/Block/Finish.php
+++ b/app/code/Midtrans/Snap/Block/Finish.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * Created by Zaki Ibrahim (c) 2019. Copyright Midtrans PT
- */
 
 namespace Midtrans\Snap\Block;
 use Magento\Framework\Registry;

--- a/app/code/Midtrans/Snap/Block/Pending.php
+++ b/app/code/Midtrans/Snap/Block/Pending.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Midtrans\Snap\Block;
 
 use \Magento\Framework\View\Element\Template;

--- a/app/code/Midtrans/Snap/Controller/Index/Close.php
+++ b/app/code/Midtrans/Snap/Controller/Index/Close.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Midtrans\Snap\Controller\Index;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+
+class Close extends Action implements HttpGetActionInterface
+{
+    protected $pageFactory;
+    protected $request;
+
+    public function __construct(Context $context, PageFactory $pageFactory)
+    {
+        $this->resultPageFactory = $pageFactory;
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        if (!$this->_objectManager->get(\Magento\Checkout\Model\Session\SuccessValidator::class)->isValid()) {
+            return $this->resultRedirectFactory->create()->setPath('checkout/cart');
+        }
+        $resultPage = $this->resultPageFactory->create();
+        return $resultPage;
+    }
+}

--- a/app/code/Midtrans/Snap/Controller/Payment/Cancel.php
+++ b/app/code/Midtrans/Snap/Controller/Payment/Cancel.php
@@ -33,10 +33,20 @@ class Cancel extends \Magento\Framework\App\Action\Action
         $orderId = $this->getValue();
 
         $order = $om->get('Magento\Sales\Model\Order')->loadByIncrementId($orderId);
-        $order->setStatus(\Magento\Sales\Model\Order::STATE_CANCELED);
-        $order->addStatusToHistory(\Magento\Sales\Model\Order::STATE_CANCELED);
-        $order->save();
-        $this->unSetValue();
+        if ($order->getState() == \Magento\Sales\Model\Order::STATE_NEW) {
+
+            $order->setStatus(\Magento\Sales\Model\Order::STATE_CANCELED);
+            $order->addStatusToHistory(\Magento\Sales\Model\Order::STATE_CANCELED);
+            $order->save();
+
+            $order->getPayment()->cancel();
+            $order->registerCancellation();
+
+            $this->unSetValue();
+            return $this->resultRedirectFactory->create()->setPath('snap/index/close');
+        } else {
+            return $this->resultRedirectFactory->create()->setPath('checkout/cart');
+        }
     }
 
     public function getValue()
@@ -50,6 +60,5 @@ class Cancel extends \Magento\Framework\App\Action\Action
         $this->_coreSession->start();
         return $this->_coreSession->unsMessage();
     }
-
 
 }

--- a/app/code/Midtrans/Snap/Controller/Payment/Notification.php
+++ b/app/code/Midtrans/Snap/Controller/Payment/Notification.php
@@ -5,9 +5,10 @@ namespace Midtrans\Snap\Controller\Payment;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Controller\ResultFactory;
 
-use Magento\Framework\App\CsrfAwareActionInterface;
+//use Magento\Framework\App\CsrfAwareActionInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
+use Midtrans\Snap\Plugin\CsrfValidatorSkip;
 
 $object_manager = \Magento\Framework\App\ObjectManager::getInstance();
 $filesystem = $object_manager->get('Magento\Framework\Filesystem');
@@ -15,7 +16,7 @@ $root = $filesystem->getDirectoryRead(DirectoryList::ROOT);
 $lib_file = $root->getAbsolutePath('lib/internal/midtrans-php/Midtrans.php');
 require_once($lib_file);
 
-class Notification extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+class Notification extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Framework\Registry
@@ -70,7 +71,7 @@ class Notification extends \Magento\Framework\App\Action\Action implements CsrfA
         $logger->info($_info);
         ##log notif snap
 
-        $order_note = "Midtrans HTTP notification received. ";
+        $order_note = "Midtrans Notification - ";
 
         if ($transaction == 'capture') {
             $order->setInstallmentTenor($notif->installment_term);
@@ -132,15 +133,5 @@ class Notification extends \Magento\Framework\App\Action\Action implements CsrfA
             }
         }
         $order->save();
-    }
-
-    public function createCsrfValidationException(RequestInterface $request): ?InvalidRequestException
-    {
-        return null;
-    }
-
-    public function validateForCsrf(RequestInterface $request): ?bool
-    {
-        return true;
     }
 }

--- a/app/code/Midtrans/Snap/Plugin/CsrfValidatorSkip.php
+++ b/app/code/Midtrans/Snap/Plugin/CsrfValidatorSkip.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Midtrans\Snap\Plugin;
+class CsrfValidatorSkip
+{
+    /**
+     * @param \Magento\Framework\App\Request\CsrfValidator $subject
+     * @param \Closure $proceed
+     * @param \Magento\Framework\App\RequestInterface $request
+     * @param \Magento\Framework\App\ActionInterface $action
+     */
+    public function aroundValidate(
+        $subject,
+        \Closure $proceed,
+        $request,
+        $action
+    ) {
+        if ($request->getModuleName() == 'snap') {
+            return; // Skip CSRF check
+        }
+        $proceed($request, $action); // Proceed Magento 2 core functionalities
+    }
+}

--- a/app/code/Midtrans/Snap/composer.json
+++ b/app/code/Midtrans/Snap/composer.json
@@ -2,7 +2,7 @@
   "name": "midtrans/snap",
   "description": "Midtrans-Snap Payment Method",
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/app/code/Midtrans/Snap/etc/frontend/di.xml
+++ b/app/code/Midtrans/Snap/etc/frontend/di.xml
@@ -16,4 +16,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\App\Request\CsrfValidator">
+        <plugin name="csrf_validator_skip" type="Midtrans\Snap\Plugin\CsrfValidatorSkip" />
+    </type>
 </config>

--- a/app/code/Midtrans/Snap/etc/module.xml
+++ b/app/code/Midtrans/Snap/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Midtrans_Snap" setup_version="2.1.0">
+    <module name="Midtrans_Snap" setup_version="2.2.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Midtrans/Snap/view/frontend/layout/snap_index_close.xml
+++ b/app/code/Midtrans/Snap/view/frontend/layout/snap_index_close.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <title>Payment Close</title>
+    </head>
+    <body>
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
+                <argument translate="true" name="title" xsi:type="string">Your order has been canceled!</argument>
+            </action>
+        </referenceBlock>
+        <referenceContainer name="content">
+            <block class="Midtrans\Snap\Block\Close" name="snap_close" template="Midtrans_Snap::close.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Midtrans/Snap/view/frontend/layout/snap_index_pending.xml
+++ b/app/code/Midtrans/Snap/view/frontend/layout/snap_index_pending.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0"?>
-
-
-
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>

--- a/app/code/Midtrans/Snap/view/frontend/templates/close.phtml
+++ b/app/code/Midtrans/Snap/view/frontend/templates/close.phtml
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * @var \Midtrans\Snap\Block\Close $block
+ */
+
+echo $block->cancelOrders(); ?>

--- a/app/code/Midtrans/Snap/view/frontend/web/js/view/payment/method-renderer/snap-method.js
+++ b/app/code/Midtrans/Snap/view/frontend/web/js/view/payment/method-renderer/snap-method.js
@@ -176,22 +176,13 @@ define(
                                                     messageList.addErrorMessage({
                                                         message: result.status_message
                                                     });
-                                                    window.location.replace(url.build('checkout/onepage/failure'));
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                     console.log(result.status_message);
                                                 },
                                                 onClose: function () {
                                                     console.log("get to onclose")
                                                     trackResult(data, merchant_id, 'Fullpayment Snap PopUp', 'close');
-                                                    $.ajax({
-                                                        url: url.build('snap/payment/cancel'),
-                                                        cache: false,
-                                                        success: function () {
-                                                            messageList.addErrorMessage({
-                                                                message: 'customer closed the popup without finishing the payment'
-                                                            });
-                                                            console.log('customer closed the popup without finishing the payment');
-                                                        }
-                                                    });
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                 }
                                             });
                                         var snapExecuted = true;

--- a/app/code/Midtrans/Snap/view/frontend/web/js/view/payment/method-renderer/snap-method.js
+++ b/app/code/Midtrans/Snap/view/frontend/web/js/view/payment/method-renderer/snap-method.js
@@ -190,7 +190,6 @@ define(
                                                                 message: 'customer closed the popup without finishing the payment'
                                                             });
                                                             console.log('customer closed the popup without finishing the payment');
-                                                            window.location.replace(url.build('checkout/onepage/failure'));
                                                         }
                                                     });
                                                 }

--- a/app/code/Midtrans/Snapinst/composer.json
+++ b/app/code/Midtrans/Snapinst/composer.json
@@ -2,7 +2,7 @@
   "name": "midtrans/snapinst",
   "description": "Midtrans-Snapint Payment Method",
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/app/code/Midtrans/Snapinst/etc/module.xml
+++ b/app/code/Midtrans/Snapinst/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Midtrans_Snapinst" setup_version="2.1.0">
+    <module name="Midtrans_Snapinst" setup_version="2.2.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Midtrans/Snapinst/view/frontend/web/js/view/payment/method-renderer/snapinst-method.js
+++ b/app/code/Midtrans/Snapinst/view/frontend/web/js/view/payment/method-renderer/snapinst-method.js
@@ -176,22 +176,13 @@ define(
                                                     messageList.addErrorMessage({
                                                         message: result.status_message
                                                     });
-                                                    window.location.replace(url.build('checkout/onepage/failure'));
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                     console.log(result.status_message);
                                                 },
                                                 onClose: function () {
                                                     console.log("get to onclose")
                                                     trackResult(data, merchant_id, 'Installment_Dragon Snap inst PopUp', 'close');
-                                                    $.ajax({
-                                                        url: url.build('snap/payment/cancel'),
-                                                        cache: false,
-                                                        success: function () {
-                                                            messageList.addErrorMessage({
-                                                                message: 'customer closed the popup without finishing the payment'
-                                                            });
-                                                            console.log('customer closed the popup without finishing the payment');
-                                                        }
-                                                    });
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                 }
                                             });
                                         var snapExecuted = true;

--- a/app/code/Midtrans/Snapinst/view/frontend/web/js/view/payment/method-renderer/snapinst-method.js
+++ b/app/code/Midtrans/Snapinst/view/frontend/web/js/view/payment/method-renderer/snapinst-method.js
@@ -190,7 +190,6 @@ define(
                                                                 message: 'customer closed the popup without finishing the payment'
                                                             });
                                                             console.log('customer closed the popup without finishing the payment');
-                                                            window.location.replace(url.build('checkout/onepage/failure'));
                                                         }
                                                     });
                                                 }

--- a/app/code/Midtrans/Snapio/composer.json
+++ b/app/code/Midtrans/Snapio/composer.json
@@ -2,7 +2,7 @@
   "name": "midtrans/snapio",
   "description": "Midtrans-Snapint Payment Method",
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/app/code/Midtrans/Snapio/etc/module.xml
+++ b/app/code/Midtrans/Snapio/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Midtrans_Snapio" setup_version="2.1.0">
+    <module name="Midtrans_Snapio" setup_version="2.2.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Midtrans/Snapio/view/frontend/web/js/view/payment/method-renderer/snapio-method.js
+++ b/app/code/Midtrans/Snapio/view/frontend/web/js/view/payment/method-renderer/snapio-method.js
@@ -175,22 +175,13 @@ define(
                                                     messageList.addErrorMessage({
                                                         message: result.status_message
                                                     });
-                                                    window.location.replace(url.build('checkout/onepage/failure'));
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                     console.log(result.status_message);
                                                 },
                                                 onClose: function () {
                                                     console.log("get to onclose")
                                                     trackResult(data, merchant_id, 'Installment_Offline Snap PopUp', 'close');
-                                                    $.ajax({
-                                                        url: url.build('snap/payment/cancel'),
-                                                        cache: false,
-                                                        success: function () {
-                                                            messageList.addErrorMessage({
-                                                                message: 'customer closed the popup without finishing the payment'
-                                                            });
-                                                            console.log('customer closed the popup without finishing the payment');
-                                                        }
-                                                    });
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                 }
                                             });
                                         var snapExecuted = true;

--- a/app/code/Midtrans/Snapio/view/frontend/web/js/view/payment/method-renderer/snapio-method.js
+++ b/app/code/Midtrans/Snapio/view/frontend/web/js/view/payment/method-renderer/snapio-method.js
@@ -189,7 +189,6 @@ define(
                                                                 message: 'customer closed the popup without finishing the payment'
                                                             });
                                                             console.log('customer closed the popup without finishing the payment');
-                                                            window.location.replace(url.build('checkout/onepage/failure'));
                                                         }
                                                     });
                                                 }

--- a/app/code/Midtrans/Snapspec/composer.json
+++ b/app/code/Midtrans/Snapspec/composer.json
@@ -2,7 +2,7 @@
   "name": "midtrans/snapspec",
   "description": "Midtrans-Snapspec Payment Method",
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/app/code/Midtrans/Snapspec/etc/module.xml
+++ b/app/code/Midtrans/Snapspec/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Midtrans_Snapspec" setup_version="2.1.0">
+    <module name="Midtrans_Snapspec" setup_version="2.2.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Midtrans/Snapspec/view/frontend/web/js/view/payment/method-renderer/snapspec-method.js
+++ b/app/code/Midtrans/Snapspec/view/frontend/web/js/view/payment/method-renderer/snapspec-method.js
@@ -191,7 +191,6 @@ define(
                                                                 message: 'customer closed the popup without finishing the payment'
                                                             });
                                                             console.log('customer closed the popup without finishing the payment');
-                                                            window.location.replace(url.build('checkout/onepage/failure'));
                                                         }
                                                     });
                                                 }

--- a/app/code/Midtrans/Snapspec/view/frontend/web/js/view/payment/method-renderer/snapspec-method.js
+++ b/app/code/Midtrans/Snapspec/view/frontend/web/js/view/payment/method-renderer/snapspec-method.js
@@ -177,22 +177,13 @@ define(
                                                     messageList.addErrorMessage({
                                                         message: result.status_message
                                                     });
-                                                    window.location.replace(url.build('checkout/onepage/failure'));
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                     console.log(result.status_message);
                                                 },
                                                 onClose: function () {
                                                     console.log("get to onclose")
                                                     trackResult(data, merchant_id, 'Fullpayment Snap Specific PopUp', 'close');
-                                                    $.ajax({
-                                                        url: url.build('snap/payment/cancel'),
-                                                        cache: false,
-                                                        success: function () {
-                                                            messageList.addErrorMessage({
-                                                                message: 'customer closed the popup without finishing the payment'
-                                                            });
-                                                            console.log('customer closed the popup without finishing the payment');
-                                                        }
-                                                    });
+                                                    window.location.replace(url.build('snap/payment/cancel'));
                                                 }
                                             });
                                         var snapExecuted = true;


### PR DESCRIPTION
- Add Snap Close landing page
- Now onError and onClose can Cancel order and  increasing Stock.
- Skip Csrf Compatibility with magento > 2.0.0 